### PR TITLE
fix: close script and html

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,4 +324,24 @@
     if(btn){btn.setAttribute('aria-pressed',String(pressed));$('#themeIcon').textContent=pressed?'☀️':'🌙';}
   }
   $('#themeToggle')?.addEventListener('click',()=>{
+    const current=html.getAttribute('data-theme')==='dark'?'light':'dark';
+    html.setAttribute('data-theme',current);
+    localStorage.setItem('theme',current);
+    const pressed=current==='dark';
+    const btn=$('#themeToggle');
+    if(btn){
+      btn.setAttribute('aria-pressed',String(pressed));
+      $('#themeIcon').textContent=pressed?'☀️':'🌙';
+    }
+  });
+
+  window.addEventListener('resize',setHeaderHeightVar);
+  initTheme();
+  setHeaderHeightVar();
+})();
+
+</script>
+
+</body>
+</html>
     


### PR DESCRIPTION
## Contexto
El archivo `index.html` estaba truncado y el bloque `<script>` no se cerraba, lo que rompía el comportamiento del tema y dejaba la página incompleta.

## Cambios
- Completar el listener de cambio de tema y cerrar el IIFE.
- Agregar `</script>`, `</body>` y `</html>` para terminar el documento correctamente.

## Pruebas
- `npx --yes htmlhint index.html`

## Riesgos
- La lógica dinámica fuera del fragmento recuperado podría faltar; verificar funcionalidad completa.

## Rollback
- Revertir commit `fix: close script and html` si aparece algún problema.

------
https://chatgpt.com/codex/tasks/task_e_689f742bd02c8331ad3cef11f37ea5c3